### PR TITLE
Bug fix for improper length decoding of transaction input data.

### DIFF
--- a/src/RLP.php
+++ b/src/RLP.php
@@ -144,7 +144,7 @@ class RLP
                 throw new RuntimeException('Invalid RLP.');
             }
             $length = hexdec($hexLength);
-            $data = mb_substr($input, $llength * 2, ($length + $llength - 1) * 2);
+            $data = mb_substr($input, $llength * 2, $length * 2);
 
             if (mb_strlen($data) < $length * 2) {
                 throw new RuntimeException('Invalid RLP.');


### PR DESCRIPTION
After updating from `0.2.x` to `0.3.x`, I noticed that when attempting to decode a transaction with a large amount of input data that it was incorrect. There were a few additional bytes at the end of the input data, yet everything else was perfectly fine.

Poking around highlighted a discrepancy within the decoding process and after amending it, worked flawlessly and could be successfully used to recover an address from a 'complex' transaction (one with input data) as well as a 'basic' transaction (one without any input data).

The reason that the rest of the decoding process was successful is because on L154 you added together `$llength + $length` as the offset for the remainder (which was composed of the start offset and length when calculating `$data`). The culprit, on L147, is that it's being both offset by `$llength` and then added to the `$length`, resulting in us having `$llength - 1` worth of additional bytes erroneously.