### PR TITLE
Change number compate to char compare

### DIFF
--- a/src/RLP.php
+++ b/src/RLP.php
@@ -80,7 +80,7 @@ class RLP
         $length = mb_strlen($input) / 2;
 
         // first byte < 0x80
-        if ($length === 1 && mb_substr($input, 0, 1) < 8) {
+        if ($length === 1 && mb_substr($input, 0, 1) < '8') {
             return $input;
         }
         return $this->encodeLength($length, 128) . $input;


### PR DESCRIPTION
Due with bug number values between 0x80 and 0xff was not encoded correctly: they are required the length prefix, but it is not added.